### PR TITLE
Cater for side effect imports

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -461,3 +461,20 @@ import typeof { a } from \\"b\\";
 \`;
 "
 `;
+
+exports[`17. import side effects 1`] = `
+"
+import \\"b\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`Path: Program (1:0,1:11)
+  body: []
+  directives: []
+  innerComments: []
+  leadingComments: []
+  sourceType: 'module'
+  trailingComments: []
+\`;
+"
+`;

--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ function explodedToStatements(exploded /*: Object */) {
     let {local, external, source} = toModuleSpecifierValues(item);
     let specifier;
 
+    // If import is for side effects, it has no specifiers.
+    if (!external && !local) {
+      return;
+    }
+
     if (!external) {
       specifier = t.importNamespaceSpecifier(local);
     } else if (item.external === 'default') {

--- a/test.js
+++ b/test.js
@@ -105,5 +105,9 @@ pluginTester({
       title: 'import typeof inner',
       code: 'import { typeof a } from "b";',
     },
+    {
+      title: 'import side effects',
+      code: 'import "b";',
+    },
   ],
 });


### PR DESCRIPTION
This caters for side effect imports like `rxjs`

`import "rxjs/..."`